### PR TITLE
Add Triton Cache metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,13 @@ if(${TRITON_ENABLE_METRICS})
   )
 endif() # TRITON_ENABLE_METRICS
 
+if(${TRITON_ENABLE_LOGGING})
+  target_compile_definitions(
+    triton-local-cache
+    PRIVATE TRITON_ENABLE_LOGGING=1
+  )
+endif() # TRITON_ENABLE_LOGGING
+
 target_link_libraries(
   triton-local-cache
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
+option(TRITON_ENABLE_METRICS "Include metrics support in cache" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
@@ -93,6 +94,13 @@ target_compile_options(
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
     -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Werror>
 )
+
+if(${TRITON_ENABLE_METRICS})
+  target_compile_definitions(
+    triton-local-cache
+    PRIVATE TRITON_ENABLE_METRICS=1
+  )
+endif() # TRITON_ENABLE_METRICS
 
 target_link_libraries(
   triton-local-cache

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 # Triton Local Cache
 
 This repo contains an example 
-[cache](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritoncache.h)
-for caching data locally in-memory.
+[TRITONCACHE API](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritoncache.h)
+implementation for caching data locally in-memory.
 
 Ask questions or report problems in the main Triton [issues
 page](https://github.com/triton-inference-server/server/issues).
@@ -42,7 +42,7 @@ page](https://github.com/triton-inference-server/server/issues).
 Use a recent cmake to build. First install the required dependencies.
 
 ```
-$ apt-get install libboost-dev
+$ apt-get install libboost-dev rapidjson-dev
 ```
 
 To build the cache:
@@ -61,23 +61,16 @@ but the following CMake arguments can be used to override.
 * triton-inference-server/core: `-D TRITON_CORE_REPO_TAG=[tag]`
 * triton-inference-server/common: `-D TRITON_COMMON_REPO_TAG=[tag]` 
 
-## Using the Cache 
+## Configuring the Cache 
 
-The cache is configured by a JSON file passed through the
-`tritonserver --cache-config config.json` CLI flag. The JSON
-file is parsed by the Cache implementation, so the fields required
-are up to the cache implementer.
+Like other `TRITONCACHE` implementations, this cache is configured through the 
+`tritonserver --cache-config` CLI arg or through the 
+`TRITONSERVER_SetCacheConfig` API.
 
-This local cache implementation only expects a `cache_size` (in bytes)
-in the config file. For example:
-
-```
-{
-  "cache_size": 4194304
-}
-```
-
-With the above configuration, the cache will be initialized with
-a size of `cache_size` (in bytes). If this value is too large or too small,
-initialization may fail.
+Currently, the following config fields are supported:
+- `size`: The fixed size (in bytes) of CPU memory allocated to the cache 
+upfront. If this value is too large (ex: greater than available memory) or 
+too small (ex: smaller than required overhead such as ~1-2 KB), initialization
+may fail.
+    - example: `tritonserver --cache-config local,size=1048576`
 

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -74,6 +74,10 @@ struct TritonMetric {
 
   TRITONSERVER_Error* Set(double value)
   {
+    if (!metric_) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL, "metric was nullptr");
+    }
     RETURN_IF_ERROR(TRITONSERVER_MetricSet(metric_, value));
     return nullptr;  // success
   }
@@ -134,8 +138,9 @@ class LocalCache {
   uint64_t num_lookups_ = 0;
   uint64_t num_hits_ = 0;
   uint64_t num_misses_ = 0;
-  uint64_t total_lookup_latency_ns_ = 0;
-  uint64_t total_insertion_latency_ns_ = 0;
+  // Lookup/Insert latencies in microseconds
+  uint64_t total_lookup_latency_us_ = 0;
+  uint64_t total_insertion_latency_us_ = 0;
   // TRITONSERVER_Metric/Family wrappers
   TritonMetric cache_util_;
   TritonMetric cache_entries_;

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -24,10 +24,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <atomic>
 #include <boost/interprocess/managed_external_buffer.hpp>
 #include <list>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 #include "triton/core/tritoncache.h"
@@ -53,6 +55,38 @@ struct CacheEntry {
   std::vector<CacheEntryItem> items_;
   // Point to key in LRU list for maintaining LRU order
   std::list<std::string>::iterator lru_iter_;
+};
+
+struct TritonMetric {
+  TRITONSERVER_MetricFamily* family_ = nullptr;
+  TRITONSERVER_Metric* metric_ = nullptr;
+
+  TRITONSERVER_Error* Init(
+      TRITONSERVER_MetricKind kind, const char* name, const char* description)
+  {
+    RETURN_IF_ERROR(
+        TRITONSERVER_MetricFamilyNew(&family_, kind, name, description));
+    std::vector<const TRITONSERVER_Parameter*> labels;
+    RETURN_IF_ERROR(TRITONSERVER_MetricNew(
+        &metric_, family_, labels.data(), labels.size()));
+    return nullptr;  // success
+  }
+
+  TRITONSERVER_Error* Set(double value)
+  {
+    RETURN_IF_ERROR(TRITONSERVER_MetricSet(metric_, value));
+    return nullptr;  // success
+  }
+
+  ~TritonMetric()
+  {
+    if (metric_) {
+      TRITONSERVER_MetricDelete(metric_);
+    }
+    if (family_) {
+      TRITONSERVER_MetricFamilyDelete(family_);
+    }
+  }
 };
 
 class LocalCache {
@@ -87,11 +121,45 @@ class LocalCache {
   // Request buffer from managed buffer
   TRITONSERVER_Error* Allocate(uint64_t byte_size, void** buffer);
 
+  // Cache Metric Helpers: note the metrics must be protected when accessed
+  TRITONSERVER_Error* InitMetrics();
+  TRITONSERVER_Error* UpdateMetrics();
+  // Returns the number of entries currently in cache
+  uint64_t NumEntries();
+  // Returns fraction of bytes allocated over total cache size between [0, 1]
+  double TotalUtilization();
+
+  // Cache Metrics: these must be protected when accessed
+  uint64_t num_evictions_ = 0;
+  uint64_t num_lookups_ = 0;
+  uint64_t num_hits_ = 0;
+  uint64_t num_misses_ = 0;
+  uint64_t total_lookup_latency_ns_ = 0;
+  uint64_t total_insertion_latency_ns_ = 0;
+  // TRITONSERVER_Metric/Family wrappers
+  TritonMetric cache_util_;
+  TritonMetric cache_entries_;
+  TritonMetric cache_hits_;
+  TritonMetric cache_misses_;
+  TritonMetric cache_lookups_;
+  TritonMetric cache_evictions_;
+  TritonMetric cache_lookup_time_;
+  TritonMetric cache_insert_time_;
+  // Thread to poll metrics at an interval
+  std::unique_ptr<std::thread> metrics_thread_;
+  std::atomic<bool> metrics_thread_exit_ = false;
+  // The interval at which metrics are updated by metric thread.
+  // Default interval is 1000ms = 1sec.
+  // NOTE: Can expose this as config field in the future
+  uint64_t metrics_interval_ms_ = 1000;
+
   // Underlying contiguous buffer managed by managed_buffer_
   void* buffer_;
   // Managed buffer
   boost::interprocess::managed_external_buffer managed_buffer_;
+  // Protect concurrent cache access
   std::mutex cache_mu_;
+  // Protect concurrent managed buffer access
   std::mutex buffer_mu_;
   // key -> CacheEntry containing values and list iterator for LRU management
   std::unordered_map<std::string, CacheEntry> cache_;


### PR DESCRIPTION
- [x] check interaction with Triton when `--allow-metrics=false`, and when Triton is built with `-D TRITON_ENABLE_METRICS=off`.