### PR TITLE
Flatten TRITONCACHE API structure, use callbacks to avoid unnecessary copies

### DIFF
--- a/src/cache_api.cc
+++ b/src/cache_api.cc
@@ -62,28 +62,9 @@ TRITONCACHE_CacheFinalize(TRITONCACHE_Cache* cache)
   return nullptr;  // success
 }
 
+// Helper
 TRITONSERVER_Error*
-TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
-    TRITONCACHE_Allocator* allocator)
-{
-  if (cache == nullptr) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "cache was nullptr");
-  } else if (entry == nullptr) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "cache entry was nullptr");
-  } else if (allocator == nullptr) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "allocator was nullptr");
-  }
-
-  const auto lcache = reinterpret_cast<LocalCache*>(cache);
-  return lcache->Lookup(key, entry, allocator);
-}
-
-TRITONSERVER_Error*
-TRITONCACHE_CacheInsert(
+CheckArgs(
     TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
     TRITONCACHE_Allocator* allocator)
 {
@@ -96,8 +77,30 @@ TRITONCACHE_CacheInsert(
   } else if (key == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "key was nullptr");
+  } else if (allocator == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "allocator was nullptr");
   }
 
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TRITONCACHE_CacheLookup(
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
+    TRITONCACHE_Allocator* allocator)
+{
+  RETURN_IF_ERROR(CheckArgs(cache, key, entry, allocator));
+  const auto lcache = reinterpret_cast<LocalCache*>(cache);
+  return lcache->Lookup(key, entry, allocator);
+}
+
+TRITONSERVER_Error*
+TRITONCACHE_CacheInsert(
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
+    TRITONCACHE_Allocator* allocator)
+{
+  RETURN_IF_ERROR(CheckArgs(cache, key, entry, allocator));
   const auto lcache = reinterpret_cast<LocalCache*>(cache);
   RETURN_IF_ERROR(lcache->Insert(key, entry, allocator));
   return nullptr;  // success

--- a/src/cache_api.cc
+++ b/src/cache_api.cc
@@ -64,7 +64,8 @@ TRITONCACHE_CacheFinalize(TRITONCACHE_Cache* cache)
 
 TRITONSERVER_Error*
 TRITONCACHE_CacheLookup(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry)
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
+    TRITONCACHE_Allocator* allocator)
 {
   if (cache == nullptr) {
     return TRITONSERVER_ErrorNew(
@@ -72,51 +73,19 @@ TRITONCACHE_CacheLookup(
   } else if (entry == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "cache entry was nullptr");
+  } else if (allocator == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "allocator was nullptr");
   }
 
   const auto lcache = reinterpret_cast<LocalCache*>(cache);
-  auto [err, lentry] = lcache->Lookup(key);
-  if (err != nullptr) {
-    return err;
-  }
-
-  for (const auto& item : lentry.items_) {
-    TRITONCACHE_CacheEntryItem* triton_item = nullptr;
-    RETURN_IF_ERROR(TRITONCACHE_CacheEntryItemNew(&triton_item));
-    for (const auto& [buffer, byte_size] : item.buffers_) {
-      if (!buffer || !byte_size) {
-        return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INTERNAL, "buffer was null or size was zero");
-      }
-
-      // Create and set buffer attributes
-      // DLIS-2673: Add better memory_type support, default to CPU memory for
-      // now
-      TRITONSERVER_BufferAttributes* buffer_attributes = nullptr;
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesNew(&buffer_attributes));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesSetByteSize(
-          buffer_attributes, byte_size));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesSetMemoryType(
-          buffer_attributes, TRITONSERVER_MEMORY_CPU));
-      RETURN_IF_ERROR(
-          TRITONSERVER_BufferAttributesSetMemoryTypeId(buffer_attributes, 0));
-      // Add buffer then clean up
-      RETURN_IF_ERROR(TRITONCACHE_CacheEntryItemAddBuffer(
-          triton_item, buffer, buffer_attributes));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesDelete(buffer_attributes));
-    }
-
-    // Pass ownership of triton_item to Triton to avoid copy. Triton will
-    // be responsible for cleaning it up, so do not call CacheEntryItemDelete.
-    RETURN_IF_ERROR(TRITONCACHE_CacheEntryAddItem(entry, triton_item));
-  }
-
-  return nullptr;  // success
+  return lcache->Lookup(key, entry, allocator);
 }
 
 TRITONSERVER_Error*
 TRITONCACHE_CacheInsert(
-    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry)
+    TRITONCACHE_Cache* cache, const char* key, TRITONCACHE_CacheEntry* entry,
+    TRITONCACHE_Allocator* allocator)
 {
   if (cache == nullptr) {
     return TRITONSERVER_ErrorNew(
@@ -127,6 +96,9 @@ TRITONCACHE_CacheInsert(
   } else if (key == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "key was nullptr");
+  } else if (allocator == nullptr) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG, "allocator was nullptr");
   }
 
   const auto lcache = reinterpret_cast<LocalCache*>(cache);
@@ -141,6 +113,7 @@ TRITONCACHE_CacheInsert(
 
   // Form cache representation of CacheEntry from Triton
   CacheEntry lentry;
+  lentry.triton_entry_ = entry;
   for (size_t item_index = 0; item_index < num_items; item_index++) {
     TRITONCACHE_CacheEntryItem* item = nullptr;
     RETURN_IF_ERROR(TRITONCACHE_CacheEntryGetItem(entry, item_index, &item));
@@ -150,26 +123,26 @@ TRITONCACHE_CacheInsert(
 
     // Form cache representation of CacheEntryItem from Triton
     CacheEntryItem litem;
+    litem.triton_item_ = item;
     for (size_t buffer_index = 0; buffer_index < num_buffers; buffer_index++) {
       // Get buffer and its buffer attributes from Triton
       void* base = nullptr;
-      TRITONSERVER_BufferAttributes* buffer_attributes = nullptr;
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesNew(&buffer_attributes));
+      TRITONSERVER_BufferAttributes* attrs = nullptr;
+      // TODO: Delete attrs on cache cleanup
+      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesNew(&attrs));
       RETURN_IF_ERROR(TRITONCACHE_CacheEntryItemGetBuffer(
-          item, buffer_index, &base, buffer_attributes));
+          item, buffer_index, &base, attrs));
 
       // Query buffer attributes then clean up
       size_t byte_size = 0;
       TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
       int64_t memory_type_id = 0;
 
+      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesByteSize(attrs, &byte_size));
       RETURN_IF_ERROR(
-          TRITONSERVER_BufferAttributesByteSize(buffer_attributes, &byte_size));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesMemoryType(
-          buffer_attributes, &memory_type));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesMemoryTypeId(
-          buffer_attributes, &memory_type_id));
-      RETURN_IF_ERROR(TRITONSERVER_BufferAttributesDelete(buffer_attributes));
+          TRITONSERVER_BufferAttributesMemoryType(attrs, &memory_type));
+      RETURN_IF_ERROR(
+          TRITONSERVER_BufferAttributesMemoryTypeId(attrs, &memory_type_id));
 
       // DLIS-2673: Add better memory_type support
       if (memory_type != TRITONSERVER_MEMORY_CPU &&
@@ -184,14 +157,15 @@ TRITONCACHE_CacheInsert(
             TRITONSERVER_ERROR_INTERNAL, "buffer size was zero");
       }
 
+      // TODO
       // Cache will replace this base pointer with a new cache-allocated base
       // pointer internally on Insert()
-      litem.buffers_.emplace_back(std::make_pair(base, byte_size));
+      litem.buffers_.emplace_back(std::make_pair(base, attrs));
     }
     lentry.items_.emplace_back(litem);
   }
 
-  RETURN_IF_ERROR(lcache->Insert(key, lentry));
+  RETURN_IF_ERROR(lcache->Insert(key, lentry, allocator));
   return nullptr;  // success
 }
 

--- a/src/cache_api.cc
+++ b/src/cache_api.cc
@@ -96,9 +96,6 @@ TRITONCACHE_CacheInsert(
   } else if (key == nullptr) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG, "key was nullptr");
-  } else if (allocator == nullptr) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG, "allocator was nullptr");
   }
 
   const auto lcache = reinterpret_cast<LocalCache*>(cache);

--- a/src/cache_api.cc
+++ b/src/cache_api.cc
@@ -109,8 +109,10 @@ TRITONCACHE_CacheInsert(
   RETURN_IF_ERROR(TRITONCACHE_CacheEntryBufferCount(entry, &num_buffers));
 
   // Form cache representation of CacheEntry from Triton
-  CacheEntry lentry;
-  lentry.triton_entry_ = entry;
+  // TODO: Move everything into LocalCache::Insert, or use smart pointer
+  // to auto handle cleanup
+  auto lentry = new CacheEntry();
+  lentry->triton_entry_ = entry;
   for (size_t buffer_index = 0; buffer_index < num_buffers; buffer_index++) {
     // Get buffer and its buffer attributes from Triton
     void* base = nullptr;
@@ -147,10 +149,15 @@ TRITONCACHE_CacheInsert(
     // TODO
     // Cache will replace this base pointer with a new cache-allocated base
     // pointer internally on Insert()
-    lentry.buffers_.emplace_back(std::make_pair(base, attrs));
+    std::cout << "Emplace base: " << base << ", attrs: " << attrs
+              << ", into local::entry: " << lentry << std::endl;
+    lentry->buffers_.emplace_back(std::make_pair(base, attrs));
   }
 
+  std::cout << "~~~~~~ [cache_api.cc] Insert lentry: " << lentry << std::endl;
   RETURN_IF_ERROR(lcache->Insert(key, lentry, allocator));
+  std::cout << "~~~~~~ [cache_api.cc] DONE Insert lentry: " << lentry
+            << std::endl;
   return nullptr;  // success
 }
 

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -54,7 +54,6 @@ TRITONSERVER_Error* CopyAttributes(
 
 struct CacheEntryItem {
   std::vector<Buffer> buffers_;
-  // TODO
   TRITONCACHE_CacheEntryItem* triton_item_;
 };
 
@@ -62,7 +61,6 @@ struct CacheEntry {
   std::vector<CacheEntryItem> items_;
   // Point to key in LRU list for maintaining LRU order
   std::list<std::string>::iterator lru_iter_;
-  // TODO
   TRITONCACHE_CacheEntry* triton_entry_;
 };
 
@@ -112,7 +110,6 @@ class LocalCache {
 
   // Lookup key in cache and return the data associated with it
   // Return TRITONSERVER_Error* object indicating success or failure.
-  // TODO
   // std::pair<TRITONSERVER_Error*, CacheEntry> Lookup(
   TRITONSERVER_Error* Lookup(
       const std::string& key, TRITONCACHE_CacheEntry* entry,

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -30,7 +30,6 @@
 #include <list>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <thread>
 #include <unordered_map>
 #include <vector>
@@ -47,28 +46,14 @@
 
 namespace triton { namespace cache { namespace local {
 
-using Buffer = std::pair<void*, TRITONSERVER_BufferAttributes*>;
-
-TRITONSERVER_Error* CopyAttributes(
-    TRITONSERVER_BufferAttributes* in, TRITONSERVER_BufferAttributes* out);
+using Buffer = std::pair<void*, std::shared_ptr<TRITONSERVER_BufferAttributes>>;
+using Metadata =
+    std::tuple<void*, size_t, std::shared_ptr<TRITONSERVER_BufferAttributes>>;
 
 struct CacheEntry {
-  ~CacheEntry()
-  {
-    std::cout << "Cleaning up local::CacheEntry: " << this << std::endl;
-    for (auto& [base, attrs] : buffers_) {
-      if (attrs) {
-        TRITONSERVER_BufferAttributesDelete(attrs);
-        attrs = nullptr;
-      }
-    }
-    std::cout << "DONE cleaning up local::CacheEntry: " << this << std::endl;
-  }
-
   std::vector<Buffer> buffers_;
   // Point to key in LRU list for maintaining LRU order
   std::list<std::string>::iterator lru_iter_;
-  TRITONCACHE_CacheEntry* triton_entry_;
 };
 
 struct TritonMetric {
@@ -125,7 +110,7 @@ class LocalCache {
   // Insert entry into cache, evict entries to make space if necessary
   // Return TRITONSERVER_Error* object indicating success or failure.
   TRITONSERVER_Error* Insert(
-      const std::string& key, CacheEntry* entry,
+      const std::string& key, TRITONCACHE_CacheEntry* entry,
       TRITONCACHE_Allocator* allocator);
 
   // Checks if key exists in cache
@@ -140,9 +125,15 @@ class LocalCache {
   LocalCache(uint64_t size);
   // Update ordering used for LRU eviction policy
   void UpdateLRU(
-      std::unordered_map<std::string, CacheEntry*>::iterator& cache_iter);
+      std::unordered_map<std::string, std::unique_ptr<CacheEntry>>::iterator&
+          cache_iter);
   // Request buffer from managed buffer
   TRITONSERVER_Error* Allocate(uint64_t byte_size, void** buffer);
+
+  // Parse and validate fields from Triton entry, store relevant fields
+  // for building cache entry in metadata
+  TRITONSERVER_Error* ParseTritonEntry(
+      TRITONCACHE_CacheEntry* entry, std::vector<Metadata>& metadata);
 
   // Cache Metric Helpers: note the metrics must be protected when accessed
   TRITONSERVER_Error* InitMetrics();
@@ -182,11 +173,11 @@ class LocalCache {
   // Managed buffer
   boost::interprocess::managed_external_buffer managed_buffer_;
   // Protect concurrent cache access
-  std::shared_mutex cache_mu_;
+  std::mutex cache_mu_;
   // Protect concurrent managed buffer access
   std::mutex buffer_mu_;
   // key -> CacheEntry containing values and list iterator for LRU management
-  std::unordered_map<std::string, CacheEntry*> cache_;
+  std::unordered_map<std::string, std::unique_ptr<CacheEntry>> cache_;
   // List of keys sorted from most to least recently used
   std::list<std::string> lru_;
 };

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -52,13 +52,8 @@ using Buffer = std::pair<void*, TRITONSERVER_BufferAttributes*>;
 TRITONSERVER_Error* CopyAttributes(
     TRITONSERVER_BufferAttributes* in, TRITONSERVER_BufferAttributes* out);
 
-struct CacheEntryItem {
-  std::vector<Buffer> buffers_;
-  TRITONCACHE_CacheEntryItem* triton_item_;
-};
-
 struct CacheEntry {
-  std::vector<CacheEntryItem> items_;
+  std::vector<Buffer> buffers_;
   // Point to key in LRU list for maintaining LRU order
   std::list<std::string>::iterator lru_iter_;
   TRITONCACHE_CacheEntry* triton_entry_;


### PR DESCRIPTION
- Removes the TRITONCACHE_EntryItem concept, flattening TRITONCACHE_Entry into a list of buffers. This simplifies the set of C APIs to maintain, and simplifies the allocation/eviction logic within the cache.
  - Each buffer will correspond to a serialized representation of an InferenceResponse in the context of Triton. This buffer will contain all of the info needed to deserialize each InferenceResponse::Output for each reponse

- Allocator/Copy callback was added to Insert to avoid an unnecessary copy when serializing a response
  - Triton will send the requested buffer size with each buffer in the TRITONCACHE_Entry object to the cache. The cache will then allocate a buffer of the requested size in the cache, and use TRITONCACHE_EntrySetBuffer to the newly allocated address. Then the TRITONCACHE_Copy / TRITONCACHE_Allocator callback combo will serialize each response into the corresponding cache-allocated buffer
- Allocator/Copy callback was added to Lookup to avoid an unnecessary copy when passing cache contents back to Triton. 
  - Since Triton needs to know the metadata related to a response in order to allocate a corresponding response buffer, the callback will atomically send the cached data back to Triton to be deserialized (to get the metadata) and copied directly into the response buffer, before returning from CacheLookup.
  
Corresponding core pr: https://github.com/triton-inference-server/core/pull/167