### PR TITLE
Update LRU in constant time

### DIFF
--- a/src/local_cache.cc
+++ b/src/local_cache.cc
@@ -421,18 +421,17 @@ LocalCache::UpdateLRU(
   // NOTE: Unique lock on cache mutex must be held for this function
 
   const auto& key = cache_iter->first;
-  const auto& cache_entry = cache_iter->second;
-  // Remove key from LRU list if it was already in there
-  auto lru_iter = std::find(lru_.begin(), lru_.end(), key);
-  if (lru_iter != lru_.end()) {
-    lru_.erase(lru_iter);
+  const auto& entry = cache_iter->second;
+  // Remove key from LRU list if entry holds valid LRU iterator already
+  if (entry->lru_iter_.valid_ && entry->lru_iter_.iter_ != lru_.end()) {
+    lru_.erase(entry->lru_iter_.iter_);
   }
   // Add key to front of LRU list since it's most recently used
   lru_.push_front(key);
-  // Set CacheEntry LRU iterator to new LRU key location
-  cache_entry->lru_iter_ = lru_.begin();
+  // Set CacheEntry LRU iterator to new LRU key location.
+  entry->lru_iter_.iter_ = lru_.begin();
+  entry->lru_iter_.valid_ = true;
 }
-
 
 // Cache Metric Helpers: these must be protected when accessed
 TRITONSERVER_Error*

--- a/src/local_cache.h
+++ b/src/local_cache.h
@@ -50,10 +50,16 @@ using Buffer = std::pair<void*, std::shared_ptr<TRITONSERVER_BufferAttributes>>;
 using Metadata =
     std::tuple<void*, size_t, std::shared_ptr<TRITONSERVER_BufferAttributes>>;
 
+struct LRUIter {
+  // iter won't be valid until set, so track its validity here for convenience
+  bool valid_ = false;
+  std::list<std::string>::iterator iter_;
+};
+
 struct CacheEntry {
   std::vector<Buffer> buffers_;
-  // Point to key in LRU list for maintaining LRU order
-  std::list<std::string>::iterator lru_iter_;
+  // Hold an LRU iterator to perform LRU updates in O(1) time.
+  LRUIter lru_iter_;
 };
 
 struct TritonMetric {


### PR DESCRIPTION
Track validity of LRU iterator, and use it directly when updating an existing key for constant time updates.

Previously, the LRU logic was mistakenly doing `O(N)` search (`std::find(list.begin(), list.end(), key)`) through the LRU keys for every update, which significantly slowed down cache operations as the number of keys in the cache grew. 

The LRU iterator logic was already there, but wasn't being used. We need a way to ensure the iterator is valid before using it to avoid undefined behavior. Rather than using a `std::pair`, I made a small struct to assign the name `valid` to the field for better readability over `pair.first` / `pair.second`.

Refs on `std::list` iterator validity after modifying the list:
> References and iterators to the erased elements are invalidated. **Other references and iterators are not affected**.
- https://en.cppreference.com/w/cpp/container/list/erase

> Lists have the important property that insertion and splicing do not invalidate iterators to list elements, and that even removal invalidates only the iterators that point to the elements that are removed
- https://stackoverflow.com/a/3329962


I will add some kind of perf tests at increasingly larger cache sizes to verify it stays relatively flat when I add the other e2e python unit tests, but for the release the performance has been verified locally and existing functional tests all pass.